### PR TITLE
feat(rds): Add IAM authentication enabled check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.metadata.json
@@ -13,10 +13,10 @@
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws rds modify-db-instance --region us-east-1 --db-instance-identifier test-database --enable-iam-database-authentication --apply-immediately",
-      "NativeIaC": "",
-      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#",
-      "Terraform": ""
+      "CLI": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#",
+      "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#",
+      "Other": "",
+      "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#"
     },
     "Recommendation": {
       "Text": "Enable IAM authentication for supported RDS instances/clusters.",

--- a/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_instance_iam_authentication_enabled",
+  "CheckTitle": "Check if RDS instances/clusters have IAM authentication enabled.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
+  "Severity": "medium",
+  "ResourceType": "AwsRdsDbInstance",
+  "Description": "Check if RDS instances/clusters have IAM authentication enabled.",
+  "Risk": "Ensure that the IAM Database Authentication feature is enabled for your RDS database instances in order to use the Identity and Access Management (IAM) service to manage database access to your MySQL and PostgreSQL database instances. With this feature enabled, you don't have to use a password when you connect to your MySQL/PostgreSQL database, instead you can use an authentication token. An authentication token is a unique string of characters with a lifetime of 15 minutes that Amazon RDS generates on your request. IAM Database Authentication removes the need of storing user credentials within the database configuration, because authentication is managed externally using Amazon IAM.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds modify-db-instance --region us-east-1 --db-instance-identifier test-database --enable-iam-database-authentication --apply-immediately",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable IAM authentication for supported RDS instances/clusters.",
+      "Url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.py
+++ b/prowler/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled.py
@@ -1,0 +1,51 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_instance_iam_authentication_enabled(Check):
+    def execute(self):
+        supported_engines = [
+            "postgres",
+            "aurora-postgresql",
+            "mysql",
+            "mariadb",
+            "aurora-mysql",
+            "aurora",
+        ]
+        findings = []
+        for db_instance in rds_client.db_instances:
+            report = Check_Report_AWS(self.metadata())
+            report.region = db_instance.region
+            report.resource_id = db_instance.id
+            report.resource_arn = db_instance.arn
+            report.resource_tags = db_instance.tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Instance {db_instance.id} does not have IAM authentication enabled."
+
+            # Check DB Instance to make sure its not part of a cluster.
+            if not db_instance.cluster_id and any(
+                engine in db_instance.engine for engine in supported_engines
+            ):
+                if db_instance.iam_auth:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"RDS Instance {db_instance.id} has IAM authentication enabled."
+                    )
+
+                findings.append(report)
+
+        for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = rds_client.db_clusters[db_cluster].region
+            report.resource_id = rds_client.db_clusters[db_cluster].id
+            report.resource_arn = db_cluster
+            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have IAM authentication enabled."
+            if rds_client.db_clusters[db_cluster].iam_auth:
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has IAM authentication enabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -71,6 +71,9 @@ class RDS(AWSService):
                                         for item in instance["DBParameterGroups"]
                                     ],
                                     multi_az=instance["MultiAZ"],
+                                    iam_auth=instance[
+                                        "IAMDatabaseAuthenticationEnabled"
+                                    ],
                                     security_groups=[
                                         sg["VpcSecurityGroupId"]
                                         for sg in instance["VpcSecurityGroups"]
@@ -227,6 +230,7 @@ class RDS(AWSService):
                                 deletion_protection=cluster["DeletionProtection"],
                                 parameter_group=cluster["DBClusterParameterGroup"],
                                 multi_az=cluster["MultiAZ"],
+                                iam_auth=cluster["IAMDatabaseAuthenticationEnabled"],
                                 region=regional_client.region,
                                 tags=cluster.get("TagList", []),
                             )
@@ -366,6 +370,7 @@ class DBInstance(BaseModel):
     auto_minor_version_upgrade: bool
     enhanced_monitoring_arn: Optional[str]
     multi_az: bool
+    iam_auth: Optional[bool]
     parameter_groups: list[str] = []
     parameters: list[dict] = []
     security_groups: list[str] = []
@@ -391,6 +396,7 @@ class DBCluster(BaseModel):
     deletion_protection: bool
     auto_minor_version_upgrade: bool
     multi_az: bool
+    iam_auth: Optional[bool]
     parameter_group: str
     force_ssl: Optional[bool]
     require_secure_transport: Optional[str]

--- a/tests/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled_test.py
@@ -56,7 +56,7 @@ class Test_rds_instance_iam_authentication_enabled:
                 assert len(result) == 0
 
     @mock_aws
-    def test_rds_aurora_instance_without_IAM_auth(self):
+    def test_rds_aurora_instance_without_iam_auth(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -107,7 +107,7 @@ class Test_rds_instance_iam_authentication_enabled:
                 assert result[0].resource_tags == []
 
     @mock_aws
-    def test_postgres_rds_instance_with_iam_auth(self):
+    def test_rds_postgres_instance_with_iam_auth(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -159,7 +159,59 @@ class Test_rds_instance_iam_authentication_enabled:
                 assert result[0].resource_tags == []
 
     @mock_aws
-    def test_mariadb_rds_instance_with_iam_auth(self):
+    def test_rds_mysql_instance_with_iam_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="mysql",
+            DBName="staging-mysql",
+            DBInstanceClass="db.m1.small",
+            EnableIAMDatabaseAuthentication=True,
+            DBParameterGroupName="test",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 has IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_mariadb_instance_with_iam_auth(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -211,7 +263,7 @@ class Test_rds_instance_iam_authentication_enabled:
                 assert result[0].resource_tags == []
 
     @mock_aws
-    def test_sqlserver_rds_instance(self):
+    def test_rds_sqlserver_instance(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -249,317 +301,108 @@ class Test_rds_instance_iam_authentication_enabled:
 
                 assert len(result) == 0
 
+    @mock_aws
+    def test_rds_aurora_postgres_clustered_without_iam_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
 
-#
-#    @mock_aws
-#    def test_mysql_rds_instance_no_ssl(self):
-#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-#        conn.create_db_parameter_group(
-#            DBParameterGroupName="test",
-#            DBParameterGroupFamily="default.mysql8.0",
-#            Description="test parameter group",
-#        )
-#        conn.create_db_instance(
-#            DBInstanceIdentifier="db-master-1",
-#            AllocatedStorage=10,
-#            Engine="mysql",
-#            DBName="staging-mysql",
-#            DBInstanceClass="db.m1.small",
-#            DBParameterGroupName="test",
-#        )
-#
-#        conn.modify_db_parameter_group(
-#            DBParameterGroupName="test",
-#            Parameters=[
-#                {
-#                    "ParameterName": "require_secure_transport",
-#                    "ParameterValue": "0",
-#                    "ApplyMethod": "immediate",
-#                },
-#            ],
-#        )
-#
-#        from prowler.providers.aws.services.rds.rds_service import RDS
-#
-#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-#
-#        with mock.patch(
-#            "prowler.providers.common.provider.Provider.get_global_provider",
-#            return_value=aws_provider,
-#        ):
-#            with mock.patch(
-#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
-#                new=RDS(aws_provider),
-#            ):
-#                # Test Check
-#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
-#                    rds_instance_iam_authentication_enabled,
-#                )
-#
-#                check = rds_instance_iam_authentication_enabled()
-#                result = check.execute()
-#
-#                assert len(result) == 1
-#                assert result[0].status == "FAIL"
-#                assert (
-#                    result[0].status_extended
-#                    == "RDS Instance db-master-1 connections are not encrypted."
-#                )
-#                assert result[0].resource_id == "db-master-1"
-#                assert result[0].region == AWS_REGION_US_EAST_1
-#                assert (
-#                    result[0].resource_arn
-#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
-#                )
-#                assert result[0].resource_tags == []
-#
-#    @mock_aws
-#    def test_mysql_rds_instance_with_ssl(self):
-#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-#        conn.create_db_parameter_group(
-#            DBParameterGroupName="test",
-#            DBParameterGroupFamily="default.mysql8.0",
-#            Description="test parameter group",
-#        )
-#        conn.create_db_instance(
-#            DBInstanceIdentifier="db-master-1",
-#            AllocatedStorage=10,
-#            Engine="mysql",
-#            DBName="staging-mysql",
-#            DBInstanceClass="db.m1.small",
-#            DBParameterGroupName="test",
-#        )
-#
-#        conn.modify_db_parameter_group(
-#            DBParameterGroupName="test",
-#            Parameters=[
-#                {
-#                    "ParameterName": "require_secure_transport",
-#                    "ParameterValue": "1",
-#                    "ApplyMethod": "immediate",
-#                },
-#            ],
-#        )
-#
-#        from prowler.providers.aws.services.rds.rds_service import RDS
-#
-#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-#
-#        with mock.patch(
-#            "prowler.providers.common.provider.Provider.get_global_provider",
-#            return_value=aws_provider,
-#        ):
-#            with mock.patch(
-#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
-#                new=RDS(aws_provider),
-#            ):
-#                # Test Check
-#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
-#                    rds_instance_iam_authentication_enabled,
-#                )
-#
-#                check = rds_instance_iam_authentication_enabled()
-#                result = check.execute()
-#
-#                assert len(result) == 1
-#                assert result[0].status == "PASS"
-#                assert (
-#                    result[0].status_extended
-#                    == "RDS Instance db-master-1 connections use SSL encryption."
-#                )
-#                assert result[0].resource_id == "db-master-1"
-#                assert result[0].region == AWS_REGION_US_EAST_1
-#                assert (
-#                    result[0].resource_arn
-#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
-#                )
-#                assert result[0].resource_tags == []
-#
-#    @mock_aws
-#    def test_postgres_rds_instance_with_ssl(self):
-#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-#        conn.create_db_parameter_group(
-#            DBParameterGroupName="test",
-#            DBParameterGroupFamily="default.postgres9.3",
-#            Description="test parameter group",
-#        )
-#        conn.create_db_instance(
-#            DBInstanceIdentifier="db-master-1",
-#            AllocatedStorage=10,
-#            Engine="postgres",
-#            DBName="staging-postgres",
-#            DBInstanceClass="db.m1.small",
-#            DBParameterGroupName="test",
-#        )
-#
-#        conn.modify_db_parameter_group(
-#            DBParameterGroupName="test",
-#            Parameters=[
-#                {
-#                    "ParameterName": "rds.force_ssl",
-#                    "ParameterValue": "1",
-#                    "ApplyMethod": "immediate",
-#                },
-#            ],
-#        )
-#
-#        from prowler.providers.aws.services.rds.rds_service import RDS
-#
-#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-#
-#        with mock.patch(
-#            "prowler.providers.common.provider.Provider.get_global_provider",
-#            return_value=aws_provider,
-#        ):
-#            with mock.patch(
-#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
-#                new=RDS(aws_provider),
-#            ):
-#                # Test Check
-#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
-#                    rds_instance_iam_authentication_enabled,
-#                )
-#
-#                check = rds_instance_iam_authentication_enabled()
-#                result = check.execute()
-#
-#                assert len(result) == 1
-#                assert result[0].status == "PASS"
-#                assert (
-#                    result[0].status_extended
-#                    == "RDS Instance db-master-1 connections use SSL encryption."
-#                )
-#                assert result[0].resource_id == "db-master-1"
-#                assert result[0].region == AWS_REGION_US_EAST_1
-#                assert (
-#                    result[0].resource_arn
-#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
-#                )
-#                assert result[0].resource_tags == []
-#
-#    @mock_aws
-#    def test_rds_postgres_clustered_instance_ssl(self):
-#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-#        conn.create_db_parameter_group(
-#            DBParameterGroupName="test",
-#            DBParameterGroupFamily="default.aurora-postgresql14",
-#            Description="test parameter group",
-#        )
-#        conn.create_db_cluster(
-#            DBClusterIdentifier="db-cluster-1",
-#            AllocatedStorage=10,
-#            Engine="aurora-postgresql",
-#            DatabaseName="staging-postgres",
-#            DeletionProtection=True,
-#            DBClusterParameterGroupName="test",
-#            MasterUsername="test",
-#            MasterUserPassword="password",
-#            Tags=[],
-#        )
-#        conn.modify_db_parameter_group(
-#            DBParameterGroupName="test",
-#            Parameters=[
-#                {
-#                    "ParameterName": "rds.force_ssl",
-#                    "ParameterValue": "1",
-#                    "ApplyMethod": "immediate",
-#                },
-#            ],
-#        )
-#        from prowler.providers.aws.services.rds.rds_service import RDS
-#
-#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-#
-#        with mock.patch(
-#            "prowler.providers.common.provider.Provider.get_global_provider",
-#            return_value=aws_provider,
-#        ):
-#            with mock.patch(
-#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
-#                new=RDS(aws_provider),
-#            ):
-#                # Test Check
-#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
-#                    rds_instance_iam_authentication_enabled,
-#                )
-#
-#                check = rds_instance_iam_authentication_enabled()
-#                result = check.execute()
-#
-#                assert len(result) == 1
-#                assert result[0].status == "PASS"
-#                assert (
-#                    result[0].status_extended
-#                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
-#                )
-#                assert result[0].resource_id == "db-cluster-1"
-#                assert result[0].region == AWS_REGION_US_EAST_1
-#                assert (
-#                    result[0].resource_arn
-#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-#                )
-#                assert result[0].resource_tags == []
-#
-#    @mock_aws
-#    def test_rds_aurora_mysql_clustered_instance_ssl(self):
-#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-#        conn.create_db_parameter_group(
-#            DBParameterGroupName="test",
-#            DBParameterGroupFamily="default.mysql8.0",
-#            Description="test parameter group",
-#        )
-#        conn.create_db_cluster(
-#            DBClusterIdentifier="db-cluster-1",
-#            AllocatedStorage=10,
-#            Engine="aurora-mysql",
-#            DatabaseName="staging-mysql",
-#            DeletionProtection=True,
-#            DBClusterParameterGroupName="test",
-#            MasterUsername="test",
-#            MasterUserPassword="password",
-#            Tags=[],
-#        )
-#        conn.modify_db_parameter_group(
-#            DBParameterGroupName="test",
-#            Parameters=[
-#                {
-#                    "ParameterName": "require_secure_transport",
-#                    "ParameterValue": "ON",
-#                    "ApplyMethod": "immediate",
-#                },
-#            ],
-#        )
-#        from prowler.providers.aws.services.rds.rds_service import RDS
-#
-#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-#
-#        with mock.patch(
-#            "prowler.providers.common.provider.Provider.get_global_provider",
-#            return_value=aws_provider,
-#        ):
-#            with mock.patch(
-#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
-#                new=RDS(aws_provider),
-#            ):
-#                # Test Check
-#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
-#                    rds_instance_iam_authentication_enabled,
-#                )
-#
-#                check = rds_instance_iam_authentication_enabled()
-#                result = check.execute()
-#
-#                assert len(result) == 1
-#                assert result[0].status == "PASS"
-#                assert (
-#                    result[0].status_extended
-#                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
-#                )
-#                assert result[0].resource_id == "db-cluster-1"
-#                assert result[0].region == AWS_REGION_US_EAST_1
-#                assert (
-#                    result[0].resource_arn
-#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-#                )
-#                assert result[0].resource_tags == []
-#
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 does not have IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_aurora_mysql_clustered_without_iam_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DatabaseName="staging-mysql",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 does not have IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_iam_authentication_enabled/rds_instance_iam_authentication_enabled_test.py
@@ -1,0 +1,565 @@
+from unittest import mock
+
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeDBEngineVersions":
+        return {
+            "DBEngineVersions": [
+                {
+                    "Engine": "mysql",
+                    "EngineVersion": "8.0.32",
+                    "DBEngineDescription": "description",
+                    "DBEngineVersionDescription": "description",
+                },
+            ]
+        }
+
+    return make_api_call(self, operation_name, kwarg)
+
+
+@mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+class Test_rds_instance_iam_authentication_enabled:
+    @mock_aws
+    def test_rds_no_instances(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_aurora_instance_without_IAM_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            EnableIAMDatabaseAuthentication=False,
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 does not have IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_postgres_rds_instance_with_iam_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.postgres9.3",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBName="staging-postgres",
+            DBInstanceClass="db.m1.small",
+            EnableIAMDatabaseAuthentication=True,
+            DBParameterGroupName="test",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 has IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_mariadb_rds_instance_with_iam_auth(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mariadb",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="mariadb",
+            DBName="staging-mariadb",
+            DBInstanceClass="db.m1.small",
+            EnableIAMDatabaseAuthentication=True,
+            DBParameterGroupName="test",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 has IAM authentication enabled."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_sqlserver_rds_instance(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.sqlserver18",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="sqlserver-ee",
+            DBName="staging-sqlserver",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+                    rds_instance_iam_authentication_enabled,
+                )
+
+                check = rds_instance_iam_authentication_enabled()
+                result = check.execute()
+
+                assert len(result) == 0
+
+
+#
+#    @mock_aws
+#    def test_mysql_rds_instance_no_ssl(self):
+#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+#        conn.create_db_parameter_group(
+#            DBParameterGroupName="test",
+#            DBParameterGroupFamily="default.mysql8.0",
+#            Description="test parameter group",
+#        )
+#        conn.create_db_instance(
+#            DBInstanceIdentifier="db-master-1",
+#            AllocatedStorage=10,
+#            Engine="mysql",
+#            DBName="staging-mysql",
+#            DBInstanceClass="db.m1.small",
+#            DBParameterGroupName="test",
+#        )
+#
+#        conn.modify_db_parameter_group(
+#            DBParameterGroupName="test",
+#            Parameters=[
+#                {
+#                    "ParameterName": "require_secure_transport",
+#                    "ParameterValue": "0",
+#                    "ApplyMethod": "immediate",
+#                },
+#            ],
+#        )
+#
+#        from prowler.providers.aws.services.rds.rds_service import RDS
+#
+#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+#
+#        with mock.patch(
+#            "prowler.providers.common.provider.Provider.get_global_provider",
+#            return_value=aws_provider,
+#        ):
+#            with mock.patch(
+#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+#                new=RDS(aws_provider),
+#            ):
+#                # Test Check
+#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+#                    rds_instance_iam_authentication_enabled,
+#                )
+#
+#                check = rds_instance_iam_authentication_enabled()
+#                result = check.execute()
+#
+#                assert len(result) == 1
+#                assert result[0].status == "FAIL"
+#                assert (
+#                    result[0].status_extended
+#                    == "RDS Instance db-master-1 connections are not encrypted."
+#                )
+#                assert result[0].resource_id == "db-master-1"
+#                assert result[0].region == AWS_REGION_US_EAST_1
+#                assert (
+#                    result[0].resource_arn
+#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+#                )
+#                assert result[0].resource_tags == []
+#
+#    @mock_aws
+#    def test_mysql_rds_instance_with_ssl(self):
+#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+#        conn.create_db_parameter_group(
+#            DBParameterGroupName="test",
+#            DBParameterGroupFamily="default.mysql8.0",
+#            Description="test parameter group",
+#        )
+#        conn.create_db_instance(
+#            DBInstanceIdentifier="db-master-1",
+#            AllocatedStorage=10,
+#            Engine="mysql",
+#            DBName="staging-mysql",
+#            DBInstanceClass="db.m1.small",
+#            DBParameterGroupName="test",
+#        )
+#
+#        conn.modify_db_parameter_group(
+#            DBParameterGroupName="test",
+#            Parameters=[
+#                {
+#                    "ParameterName": "require_secure_transport",
+#                    "ParameterValue": "1",
+#                    "ApplyMethod": "immediate",
+#                },
+#            ],
+#        )
+#
+#        from prowler.providers.aws.services.rds.rds_service import RDS
+#
+#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+#
+#        with mock.patch(
+#            "prowler.providers.common.provider.Provider.get_global_provider",
+#            return_value=aws_provider,
+#        ):
+#            with mock.patch(
+#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+#                new=RDS(aws_provider),
+#            ):
+#                # Test Check
+#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+#                    rds_instance_iam_authentication_enabled,
+#                )
+#
+#                check = rds_instance_iam_authentication_enabled()
+#                result = check.execute()
+#
+#                assert len(result) == 1
+#                assert result[0].status == "PASS"
+#                assert (
+#                    result[0].status_extended
+#                    == "RDS Instance db-master-1 connections use SSL encryption."
+#                )
+#                assert result[0].resource_id == "db-master-1"
+#                assert result[0].region == AWS_REGION_US_EAST_1
+#                assert (
+#                    result[0].resource_arn
+#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+#                )
+#                assert result[0].resource_tags == []
+#
+#    @mock_aws
+#    def test_postgres_rds_instance_with_ssl(self):
+#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+#        conn.create_db_parameter_group(
+#            DBParameterGroupName="test",
+#            DBParameterGroupFamily="default.postgres9.3",
+#            Description="test parameter group",
+#        )
+#        conn.create_db_instance(
+#            DBInstanceIdentifier="db-master-1",
+#            AllocatedStorage=10,
+#            Engine="postgres",
+#            DBName="staging-postgres",
+#            DBInstanceClass="db.m1.small",
+#            DBParameterGroupName="test",
+#        )
+#
+#        conn.modify_db_parameter_group(
+#            DBParameterGroupName="test",
+#            Parameters=[
+#                {
+#                    "ParameterName": "rds.force_ssl",
+#                    "ParameterValue": "1",
+#                    "ApplyMethod": "immediate",
+#                },
+#            ],
+#        )
+#
+#        from prowler.providers.aws.services.rds.rds_service import RDS
+#
+#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+#
+#        with mock.patch(
+#            "prowler.providers.common.provider.Provider.get_global_provider",
+#            return_value=aws_provider,
+#        ):
+#            with mock.patch(
+#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+#                new=RDS(aws_provider),
+#            ):
+#                # Test Check
+#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+#                    rds_instance_iam_authentication_enabled,
+#                )
+#
+#                check = rds_instance_iam_authentication_enabled()
+#                result = check.execute()
+#
+#                assert len(result) == 1
+#                assert result[0].status == "PASS"
+#                assert (
+#                    result[0].status_extended
+#                    == "RDS Instance db-master-1 connections use SSL encryption."
+#                )
+#                assert result[0].resource_id == "db-master-1"
+#                assert result[0].region == AWS_REGION_US_EAST_1
+#                assert (
+#                    result[0].resource_arn
+#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+#                )
+#                assert result[0].resource_tags == []
+#
+#    @mock_aws
+#    def test_rds_postgres_clustered_instance_ssl(self):
+#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+#        conn.create_db_parameter_group(
+#            DBParameterGroupName="test",
+#            DBParameterGroupFamily="default.aurora-postgresql14",
+#            Description="test parameter group",
+#        )
+#        conn.create_db_cluster(
+#            DBClusterIdentifier="db-cluster-1",
+#            AllocatedStorage=10,
+#            Engine="aurora-postgresql",
+#            DatabaseName="staging-postgres",
+#            DeletionProtection=True,
+#            DBClusterParameterGroupName="test",
+#            MasterUsername="test",
+#            MasterUserPassword="password",
+#            Tags=[],
+#        )
+#        conn.modify_db_parameter_group(
+#            DBParameterGroupName="test",
+#            Parameters=[
+#                {
+#                    "ParameterName": "rds.force_ssl",
+#                    "ParameterValue": "1",
+#                    "ApplyMethod": "immediate",
+#                },
+#            ],
+#        )
+#        from prowler.providers.aws.services.rds.rds_service import RDS
+#
+#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+#
+#        with mock.patch(
+#            "prowler.providers.common.provider.Provider.get_global_provider",
+#            return_value=aws_provider,
+#        ):
+#            with mock.patch(
+#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+#                new=RDS(aws_provider),
+#            ):
+#                # Test Check
+#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+#                    rds_instance_iam_authentication_enabled,
+#                )
+#
+#                check = rds_instance_iam_authentication_enabled()
+#                result = check.execute()
+#
+#                assert len(result) == 1
+#                assert result[0].status == "PASS"
+#                assert (
+#                    result[0].status_extended
+#                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+#                )
+#                assert result[0].resource_id == "db-cluster-1"
+#                assert result[0].region == AWS_REGION_US_EAST_1
+#                assert (
+#                    result[0].resource_arn
+#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+#                )
+#                assert result[0].resource_tags == []
+#
+#    @mock_aws
+#    def test_rds_aurora_mysql_clustered_instance_ssl(self):
+#        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+#        conn.create_db_parameter_group(
+#            DBParameterGroupName="test",
+#            DBParameterGroupFamily="default.mysql8.0",
+#            Description="test parameter group",
+#        )
+#        conn.create_db_cluster(
+#            DBClusterIdentifier="db-cluster-1",
+#            AllocatedStorage=10,
+#            Engine="aurora-mysql",
+#            DatabaseName="staging-mysql",
+#            DeletionProtection=True,
+#            DBClusterParameterGroupName="test",
+#            MasterUsername="test",
+#            MasterUserPassword="password",
+#            Tags=[],
+#        )
+#        conn.modify_db_parameter_group(
+#            DBParameterGroupName="test",
+#            Parameters=[
+#                {
+#                    "ParameterName": "require_secure_transport",
+#                    "ParameterValue": "ON",
+#                    "ApplyMethod": "immediate",
+#                },
+#            ],
+#        )
+#        from prowler.providers.aws.services.rds.rds_service import RDS
+#
+#        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+#
+#        with mock.patch(
+#            "prowler.providers.common.provider.Provider.get_global_provider",
+#            return_value=aws_provider,
+#        ):
+#            with mock.patch(
+#                "prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled.rds_client",
+#                new=RDS(aws_provider),
+#            ):
+#                # Test Check
+#                from prowler.providers.aws.services.rds.rds_instance_iam_authentication_enabled.rds_instance_iam_authentication_enabled import (
+#                    rds_instance_iam_authentication_enabled,
+#                )
+#
+#                check = rds_instance_iam_authentication_enabled()
+#                result = check.execute()
+#
+#                assert len(result) == 1
+#                assert result[0].status == "PASS"
+#                assert (
+#                    result[0].status_extended
+#                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+#                )
+#                assert result[0].resource_id == "db-cluster-1"
+#                assert result[0].region == AWS_REGION_US_EAST_1
+#                assert (
+#                    result[0].resource_arn
+#                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+#                )
+#                assert result[0].resource_tags == []
+#


### PR DESCRIPTION
### Context

Ensure IAM Authentication is enabled for DB Instances/Clusters

### Description

With this feature enabled, you don't have to use a password when you connect to your MySQL/PostgreSQL database, instead you can use an authentication token. An authentication token is a unique string of characters with a lifetime of 15 minutes that Amazon RDS generates on your request. IAM Database Authentication removes the need of storing user credentials within the database configuration, because authentication is managed externally using Amazon IAM.

DB Instances
https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/iam-database-authentication.html#
https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-10

DB Clusters
https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-12

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.