### PR TITLE
feat(rds): Aurora MySQL clusters backtrack enabled check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_cluster_backtrack_enabled",
+  "CheckTitle": "Check if RDS Aurora MySQL Clusters have backtrack enabled.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "Severity": "medium",
+  "ResourceType": "AwsRdsDbClsuter",
+  "Description": "Ensure that the Backtrack feature is enabled for your Amazon Aurora (with MySQL compatibility) database clusters in order to backtrack your clusters to a specific time, without using backups. Backtrack is an Amazon RDS feature that allows you to specify the amount of time that an Aurora MySQL database cluster needs to retain change records, in order to have a fast way to recover from user errors, such as dropping the wrong table or deleting the wrong row by moving your MySQL database to a prior point in time without the need to restore from a recent backup.",
+  "Risk": "Once the Backtrack feature is enabled, Amazon RDS can quickly \"rewind\" your Aurora MySQL database cluster to a point in time that you specify. In contrast to the backup and restore method, with Backtrack you can easily undo a destructive action, such as a DELETE query without a WHERE clause, with minimal downtime, you can rewind your Aurora cluster in just few minutes, and you can repeatedly backtrack a database cluster back and forth in time to help determine when a particular data change occurred.",
+  "RelatedUrl": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-14",
+  "Remediation": {
+    "Code": {
+      "CLI": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/backtrack.html#",
+      "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/backtrack.html#",
+      "Other": "",
+      "Terraform": "https://docs.prowler.com/checks/aws/general-policies/ensure-that-rds-instances-have-backup-policy#terraform"
+    },
+    "Recommendation": {
+      "Text": "Backups help you to recover more quickly from a security incident. They also strengthens the resilience of your systems. Aurora backtracking reduces the time to recover a database to a point in time. It does not require a database restore to do so. You cannot enable backtracking on an existing cluster. Instead, you can create a clone that has backtracking enabled.",
+      "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-14"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.py
@@ -6,15 +6,15 @@ class rds_cluster_backtrack_enabled(Check):
     def execute(self):
         findings = []
         for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = rds_client.db_clusters[db_cluster].region
+            report.resource_id = rds_client.db_clusters[db_cluster].id
+            report.resource_arn = db_cluster
+            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have backtrack enabled."
+            # Only RDS Aurora MySQL clusters support backtrack.
             if rds_client.db_clusters[db_cluster].engine == "aurora-mysql":
-                report = Check_Report_AWS(self.metadata())
-                report.region = rds_client.db_clusters[db_cluster].region
-                report.resource_id = rds_client.db_clusters[db_cluster].id
-                report.resource_arn = rds_client.db_clusters[db_cluster].arn
-                report.resource_tags = rds_client.db_clusters[db_cluster].tags
-                report.status = "FAIL"
-                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have backtrack enabled."
-                # Check RDS Clusters that support TLS encryption
                 if rds_client.db_clusters[db_cluster].backtrack > 0:
                     report.status = "PASS"
                     report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has backtrack enabled."

--- a/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled.py
@@ -1,0 +1,24 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_cluster_backtrack_enabled(Check):
+    def execute(self):
+        findings = []
+        for db_cluster in rds_client.db_clusters:
+            if rds_client.db_clusters[db_cluster].engine == "aurora-mysql":
+                report = Check_Report_AWS(self.metadata())
+                report.region = rds_client.db_clusters[db_cluster].region
+                report.resource_id = rds_client.db_clusters[db_cluster].id
+                report.resource_arn = rds_client.db_clusters[db_cluster].arn
+                report.resource_tags = rds_client.db_clusters[db_cluster].tags
+                report.status = "FAIL"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have backtrack enabled."
+                # Check RDS Clusters that support TLS encryption
+                if rds_client.db_clusters[db_cluster].backtrack > 0:
+                    report.status = "PASS"
+                    report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has backtrack enabled."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -221,6 +221,7 @@ class RDS(AWSService):
                                 backup_retention_period=cluster.get(
                                     "BackupRetentionPeriod"
                                 ),
+                                backtrack=cluster.get("BacktrackWindow"),
                                 cloudwatch_logs=cluster.get(
                                     "EnabledCloudwatchLogsExports"
                                 ),
@@ -387,6 +388,7 @@ class DBCluster(BaseModel):
     public: bool
     encrypted: bool
     backup_retention_period: int = 0
+    backtrack: int = 0
     cloudwatch_logs: Optional[list]
     deletion_protection: bool
     auto_minor_version_upgrade: bool

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -221,7 +221,7 @@ class RDS(AWSService):
                                 backup_retention_period=cluster.get(
                                     "BackupRetentionPeriod"
                                 ),
-                                backtrack=cluster.get("BacktrackWindow"),
+                                backtrack=cluster.get("BacktrackWindow", 0),
                                 cloudwatch_logs=cluster.get(
                                     "EnabledCloudwatchLogsExports"
                                 ),

--- a/tests/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled_test.py
@@ -1,146 +1,165 @@
 from unittest import mock
 
-from prowler.providers.aws.services.rds.rds_service import DBCluster
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeDBEngineVersions":
+        return {
+            "DBEngineVersions": [
+                {
+                    "Engine": "mysql",
+                    "EngineVersion": "8.0.32",
+                    "DBEngineDescription": "description",
+                    "DBEngineVersionDescription": "description",
+                },
+            ]
+        }
+    return make_api_call(self, operation_name, kwarg)
 
 
 # Currently have to mock the tests as moto does not return the value for backtrack. Issue: https://github.com/getmoto/moto/issues/7734
+@mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_cluster_backtrack_enabled:
+    @mock_aws
     def test_no_rds_clusters(self):
-        rds_client = mock.MagicMock
-        rds_client.db_clusters = {}
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.rds.rds_service.RDS",
-            rds_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ):
-            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
-                rds_cluster_backtrack_enabled,
-            )
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                    rds_cluster_backtrack_enabled,
+                )
 
-            check = rds_cluster_backtrack_enabled()
-            result = check.execute()
-            assert len(result) == 0
+                check = rds_cluster_backtrack_enabled()
+                result = check.execute()
 
-    def test_rds_cluster_aurora_mysql_backtrack_enabled(self):
-        rds_client = mock.MagicMock
-        rds_client.db_clusters = {}
-        rds_client.db_clusters["db-cluster"] = DBCluster(
-            id="db-cluster-1",
-            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
-            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
-            engine="aurora-mysql",
-            status="available",
-            public=False,
-            encrypted=True,
-            auto_minor_version_upgrade=True,
-            backup_retention_period=1,
-            backtrack=86400,
-            cloudwatch_logs=[],
-            deletion_protection=True,
-            parameter_group="test",
-            multi_az=True,
-            region=AWS_REGION_US_EAST_1,
-            tags=[],
-        )
-        with mock.patch(
-            "prowler.providers.aws.services.rds.rds_service.RDS",
-            rds_client,
-        ):
-            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
-                rds_cluster_backtrack_enabled,
-            )
+                assert len(result) == 0
 
-            check = rds_cluster_backtrack_enabled()
-            result = check.execute()
-            assert len(result) == 1
-            assert result[0].status == "PASS"
-            assert (
-                result[0].status_extended
-                == "RDS Cluster db-cluster-1 has backtrack enabled."
-            )
-            assert result[0].resource_id == "db-cluster-1"
-            assert result[0].region == AWS_REGION_US_EAST_1
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-            )
-            assert result[0].resource_tags == []
-
+    @mock_aws
     def test_rds_cluster_aurora_mysql_backtrack_disabled(self):
-        rds_client = mock.MagicMock
-        rds_client.db_clusters = {}
-        rds_client.db_clusters["db-cluster"] = DBCluster(
-            id="db-cluster-1",
-            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
-            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
-            engine="aurora-mysql",
-            status="available",
-            public=False,
-            encrypted=True,
-            auto_minor_version_upgrade=True,
-            backup_retention_period=1,
-            backtrack=0,
-            cloudwatch_logs=[],
-            deletion_protection=True,
-            parameter_group="test",
-            multi_az=True,
-            region=AWS_REGION_US_EAST_1,
-            tags=[],
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
         )
-        with mock.patch(
-            "prowler.providers.aws.services.rds.rds_service.RDS",
-            rds_client,
-        ):
-            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
-                rds_cluster_backtrack_enabled,
-            )
-
-            check = rds_cluster_backtrack_enabled()
-            result = check.execute()
-            assert len(result) == 1
-            assert result[0].status == "FAIL"
-            assert (
-                result[0].status_extended
-                == "RDS Cluster db-cluster-1 does not have backtrack enabled."
-            )
-            assert result[0].resource_id == "db-cluster-1"
-            assert result[0].region == AWS_REGION_US_EAST_1
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-            )
-            assert result[0].resource_tags == []
-
-    # Expeted to return nothing as only Aurora MySQL has backtrack features
-    def test_rds_cluster_aurora_postgres(self):
-        rds_client = mock.MagicMock
-        rds_client.db_clusters = {}
-        rds_client.db_clusters["db-cluster"] = DBCluster(
-            id="db-cluster-1",
-            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
-            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
-            engine="aurora-postgres",
-            status="available",
-            public=False,
-            encrypted=True,
-            auto_minor_version_upgrade=True,
-            backup_retention_period=1,
-            backtrack=0,
-            cloudwatch_logs=[],
-            deletion_protection=True,
-            parameter_group="test",
-            multi_az=True,
-            region=AWS_REGION_US_EAST_1,
-            tags=[],
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DatabaseName="staging-mysql",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
         )
-        with mock.patch(
-            "prowler.providers.aws.services.rds.rds_service.RDS",
-            rds_client,
-        ):
-            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
-                rds_cluster_backtrack_enabled,
-            )
+        conn.modify_db_parameter_group(
+            DBParameterGroupName="test",
+            Parameters=[
+                {
+                    "ParameterName": "require_secure_transport",
+                    "ParameterValue": "ON",
+                    "ApplyMethod": "immediate",
+                },
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
 
-            check = rds_cluster_backtrack_enabled()
-            result = check.execute()
-            assert len(result) == 0
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                    rds_cluster_backtrack_enabled,
+                )
+
+                check = rds_cluster_backtrack_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 does not have backtrack enabled."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+
+#    def test_rds_cluster_aurora_mysql_backtrack_enabled(self):
+#        rds_client = mock.MagicMock
+#        rds_client.db_clusters = {}
+#        db_cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+#        db_cluster = DBCluster(
+#            id="db-cluster-1",
+#            arn=db_cluster_arn,
+#            engine="aurora-mysql",
+#            status="available",
+#            public=False,
+#            encrypted=True,
+#            auto_minor_version_upgrade=True,
+#            backtrack=1,
+#            deletion_protection=True,
+#            parameter_group="test",
+#            multi_az=True,
+#            region=AWS_REGION_US_EAST_1,
+#            tags=[],
+#        )
+#        rds_client.db_clusters[db_cluster_arn] = db_cluster
+#
+#        with mock.patch(
+#            "prowler.providers.aws.services.rds.rds_service.RDS",
+#            rds_client,
+#        ):
+#            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+#                rds_cluster_backtrack_enabled,
+#            )
+#
+#            check = rds_cluster_backtrack_enabled()
+#            result = check.execute()
+#
+#            assert len(result) == 1
+#            assert result[0].status == "PASS"
+#            assert (
+#                result[0].status_extended
+#                == "RDS Cluster db-cluster-1 has backtrack enabled."
+#            )
+#            assert result[0].resource_id == "db-cluster-1"
+#            assert result[0].region == AWS_REGION_US_EAST_1
+#            assert (
+#                result[0].resource_arn
+#                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+#            )
+#            assert result[0].resource_tags == []
+#

--- a/tests/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_backtrack_enabled/rds_cluster_backtrack_enabled_test.py
@@ -1,0 +1,146 @@
+from unittest import mock
+
+from prowler.providers.aws.services.rds.rds_service import DBCluster
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+
+
+# Currently have to mock the tests as moto does not return the value for backtrack. Issue: https://github.com/getmoto/moto/issues/7734
+class Test_rds_cluster_backtrack_enabled:
+    def test_no_rds_clusters(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {}
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                rds_cluster_backtrack_enabled,
+            )
+
+            check = rds_cluster_backtrack_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_rds_cluster_aurora_mysql_backtrack_enabled(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {}
+        rds_client.db_clusters["db-cluster"] = DBCluster(
+            id="db-cluster-1",
+            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
+            engine="aurora-mysql",
+            status="available",
+            public=False,
+            encrypted=True,
+            auto_minor_version_upgrade=True,
+            backup_retention_period=1,
+            backtrack=86400,
+            cloudwatch_logs=[],
+            deletion_protection=True,
+            parameter_group="test",
+            multi_az=True,
+            region=AWS_REGION_US_EAST_1,
+            tags=[],
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                rds_cluster_backtrack_enabled,
+            )
+
+            check = rds_cluster_backtrack_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 has backtrack enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+            )
+            assert result[0].resource_tags == []
+
+    def test_rds_cluster_aurora_mysql_backtrack_disabled(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {}
+        rds_client.db_clusters["db-cluster"] = DBCluster(
+            id="db-cluster-1",
+            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
+            engine="aurora-mysql",
+            status="available",
+            public=False,
+            encrypted=True,
+            auto_minor_version_upgrade=True,
+            backup_retention_period=1,
+            backtrack=0,
+            cloudwatch_logs=[],
+            deletion_protection=True,
+            parameter_group="test",
+            multi_az=True,
+            region=AWS_REGION_US_EAST_1,
+            tags=[],
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                rds_cluster_backtrack_enabled,
+            )
+
+            check = rds_cluster_backtrack_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 does not have backtrack enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+            )
+            assert result[0].resource_tags == []
+
+    # Expeted to return nothing as only Aurora MySQL has backtrack features
+    def test_rds_cluster_aurora_postgres(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {}
+        rds_client.db_clusters["db-cluster"] = DBCluster(
+            id="db-cluster-1",
+            arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+            endpoint=f"db-cluster-1.cluster-cnpexample.{AWS_REGION_US_EAST_1}.rds.amazonaws.com",
+            engine="aurora-postgres",
+            status="available",
+            public=False,
+            encrypted=True,
+            auto_minor_version_upgrade=True,
+            backup_retention_period=1,
+            backtrack=0,
+            cloudwatch_logs=[],
+            deletion_protection=True,
+            parameter_group="test",
+            multi_az=True,
+            region=AWS_REGION_US_EAST_1,
+            tags=[],
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_backtrack_enabled.rds_cluster_backtrack_enabled import (
+                rds_cluster_backtrack_enabled,
+            )
+
+            check = rds_cluster_backtrack_enabled()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Context

Ensure Backtrack is enabled on Aurora MySQL Clusters

### Description

Ensure that the Backtrack feature is enabled for your Amazon Aurora (with MySQL compatibility) database clusters in order to backtrack your clusters to a specific time, without using backups. Backtrack is an Amazon RDS feature that allows you to specify the amount of time that an Aurora MySQL database cluster needs to retain change records, in order to have a fast way to recover from user errors, such as dropping the wrong table or deleting the wrong row by moving your MySQL database to a prior point in time without the need to restore from a recent backup.

Trend Cloud Conformity has it as a low priority
AWS RDS Controls has it as medium priority

DB Clusters
https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/backtrack.html#
https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-14
https://docs.aws.amazon.com/config/latest/developerguide/aurora-mysql-backtracking-enabled.html

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.