### PR TITLE
feat(rds): Add default admin user check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_instance_default_admin",
+  "CheckTitle": "Ensure that your Amazon RDS instances/clusters are not using the default master username.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
+  "Severity": "medium",
+  "ResourceType": "AwsRdsDbInstance",
+  "Description": "Ensure that your Amazon RDS instances/clusters are not using the default master username.",
+  "Risk": "Since admin is the Amazon's example for the RDS database master username and postgres is the default PostgreSQL master username. Many AWS customers will use this username for their RDS database instances in production. Malicious users can use this information to their advantage and frequently try to use default master username during brute-force attacks.",
+  "RelatedUrl": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-25",
+  "Remediation": {
+    "Code": {
+      "CLI": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-master-username.html#",
+      "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-master-username.html#",
+      "Other": "",
+      "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-master-username.html#"
+    },
+    "Recommendation": {
+      "Text": "To change the master username configured for your Amazon RDS database instances/clusters you must re-create them and migrate the existing data.",
+      "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-25"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin.py
+++ b/prowler/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin.py
@@ -1,0 +1,48 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_instance_default_admin(Check):
+    def execute(self):
+        findings = []
+        for db_instance in rds_client.db_instances:
+            report = Check_Report_AWS(self.metadata())
+            report.region = db_instance.region
+            report.resource_id = db_instance.id
+            report.resource_arn = db_instance.arn
+            report.resource_tags = db_instance.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"RDS Instance {db_instance.id} is using the default master username."
+            )
+
+            # Check only RDS DB instances that support parameter group encryption
+            if not db_instance.cluster_id:
+                if (
+                    db_instance.username != "admin"
+                    and db_instance.username != "postgres"
+                ):
+                    report.status = "PASS"
+                    report.status_extended = f"RDS Instance {db_instance.id} is not using the default master username."
+
+                findings.append(report)
+
+        for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = rds_client.db_clusters[db_cluster].region
+            report.resource_id = rds_client.db_clusters[db_cluster].id
+            report.resource_arn = db_cluster
+            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} is using the default master username."
+            # Check RDS Clusters that support TLS encryption
+            if (
+                rds_client.db_clusters[db_cluster].username != "admin"
+                and rds_client.db_clusters[db_cluster].username != "postgres"
+            ):
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} is not using the default master username."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -81,6 +81,7 @@ class RDS(AWSService):
                                         for item in instance["DBParameterGroups"]
                                     ],
                                     multi_az=instance["MultiAZ"],
+                                    username=instance["MasterUsername"],
                                     security_groups=[
                                         sg["VpcSecurityGroupId"]
                                         for sg in instance["VpcSecurityGroups"]
@@ -242,6 +243,7 @@ class RDS(AWSService):
                                             "DBClusterParameterGroup"
                                         ],
                                         multi_az=cluster["MultiAZ"],
+                                        username=cluster["MasterUsername"],
                                         region=regional_client.region,
                                         tags=cluster.get("TagList", []),
                                     )
@@ -476,6 +478,7 @@ class DBInstance(BaseModel):
     auto_minor_version_upgrade: bool
     enhanced_monitoring_arn: Optional[str]
     multi_az: bool
+    username: Optional[str]
     parameter_groups: list[str] = []
     parameters: list[dict] = []
     security_groups: list[str] = []
@@ -501,6 +504,7 @@ class DBCluster(BaseModel):
     deletion_protection: bool
     auto_minor_version_upgrade: bool
     multi_az: bool
+    username: Optional[str]
     parameter_group: str
     force_ssl: str = "0"
     require_secure_transport: str = "OFF"

--- a/tests/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_default_admin/rds_instance_default_admin_test.py
@@ -1,0 +1,264 @@
+from unittest import mock
+
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeDBEngineVersions":
+        return {
+            "DBEngineVersions": [
+                {
+                    "Engine": "mysql",
+                    "EngineVersion": "8.0.32",
+                    "DBEngineDescription": "description",
+                    "DBEngineVersionDescription": "description",
+                },
+            ]
+        }
+    return make_api_call(self, operation_name, kwarg)
+
+
+@mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+class Test_rds_instance_default_admin:
+    @mock_aws
+    def test_rds_no_instances(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin import (
+                    rds_instance_default_admin,
+                )
+
+                check = rds_instance_default_admin()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_instance_with_default_username(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            MasterUsername="postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin import (
+                    rds_instance_default_admin,
+                )
+
+                check = rds_instance_default_admin()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is using the default master username."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_instance_without_default_username(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            MasterUsername="postgres2",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin import (
+                    rds_instance_default_admin,
+                )
+
+                check = rds_instance_default_admin()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is not using the default master username."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_clustered_with_default_username(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin import (
+                    rds_instance_default_admin,
+                )
+
+                check = rds_instance_default_admin()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 is using the default master username."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_clustered_without_default_username(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DatabaseName="staging-mysql",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_default_admin.rds_instance_default_admin import (
+                    rds_instance_default_admin,
+                )
+
+                check = rds_instance_default_admin()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 is not using the default master username."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

Add default admin user check.

### Description

All RDS DB instances/clusters use ```admin``` as a default username other than PostgreSQL based instances/clusters which use ```postgres``` as the default user. Added checks to find both ```admin``` and ```postgres``` being the default admin username. 

Trend Cloud Conformity and AWS RDS Controls only check for ```admin```, but I also added ```postgres``` as that is the default PostgreSQL username to the check are more robust.

https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-master-username.html#
https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-25

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
